### PR TITLE
fix: support @langchain/core v1.x

### DIFF
--- a/libs/langchain-gigachat/package.json
+++ b/libs/langchain-gigachat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "langchain-gigachat",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "GigaChat integration for LangChain.js",
   "type": "module",
   "engines": {
@@ -52,7 +52,7 @@
     "zod-to-json-schema": "^3.23.5"
   },
   "peerDependencies": {
-    "@langchain/core": ">=0.2.21 <0.4.0"
+    "@langchain/core": ">=0.2.21 <2.0.0"
   },
   "devDependencies": {
     "@jest/globals": "^29.5.0",

--- a/libs/langchain-gigachat/src/chat_models.ts
+++ b/libs/langchain-gigachat/src/chat_models.ts
@@ -37,6 +37,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { isLangChainTool } from "@langchain/core/utils/function_calling";
 import {
   Runnable,
+  RunnableBinding,
   RunnablePassthrough,
   RunnableSequence,
 } from "@langchain/core/runnables";
@@ -458,10 +459,14 @@ export class GigaChat<
     tools: ChatGigaChatToolType[],
     kwargs?: Partial<CallOptions>
   ): Runnable<BaseLanguageModelInput, AIMessageChunk, CallOptions> {
-    return this.bind({
-      tools: this.formatStructuredToolToGigaChat(tools),
-      ...kwargs,
-    } as Partial<CallOptions>);
+    return new RunnableBinding({
+      bound: this as Runnable<BaseLanguageModelInput, AIMessageChunk, CallOptions>,
+      kwargs: {
+        tools: this.formatStructuredToolToGigaChat(tools),
+        ...kwargs,
+      } as Partial<CallOptions>,
+      config: {},
+    });
   }
 
   /**
@@ -484,7 +489,8 @@ export class GigaChat<
         return {
           name: tool.name,
           description: tool.description,
-          parameters: zodToJsonSchema(tool.schema) as FunctionParameters,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          parameters: zodToJsonSchema(tool.schema as any) as FunctionParameters,
         };
       }
       throw new Error(


### PR DESCRIPTION
## Summary
- Widen `peerDependencies` range for `@langchain/core` from `>=0.2.21 <0.4.0` to `>=0.2.21 <2.0.0` to support v1.x
- Replace removed `Runnable.bind()` with `new RunnableBinding()` in `bindTools()` — `bind()` was removed from `Runnable` in `@langchain/core` v1.x
- Fix `zodToJsonSchema` type compatibility for the `ToolInputSchemaBase` union type (zod v3/v4 support in `@langchain/core` v1.x)

Follows the Python repo's lead ([PR #58](https://github.com/ai-forever/langchain-gigachat/pull/58)) which already migrated to langchain-core 1.x.

## Test plan
- [x] TypeScript compilation passes with `@langchain/core@1.1.36`
- [ ] Verify `bindTools()` works correctly at runtime
- [ ] Verify `withStructuredOutput()` works correctly at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)