### PR TITLE
fix(langchain-gigachat): prevent xHeaders duplication during streaming

### DIFF
--- a/libs/langchain-gigachat/src/chat_models.ts
+++ b/libs/langchain-gigachat/src/chat_models.ts
@@ -469,12 +469,17 @@ function _convertDeltaToMessageChunk(
         index,
       });
     }
+    // Only set xHeaders on the first chunk (index === 0) to prevent
+    // string concatenation of header values during BaseMessageChunk.concat().
+    // LangChain's merge_dicts concatenates string values, so repeated
+    // xHeaders on every chunk causes xRequestID/xSessionID to grow
+    // with each streaming chunk (e.g. "abc-123abc-123abc-123...").
+    const response_metadata: Record<string, unknown> =
+      index === 0 ? { xHeaders: chunk.xHeaders } : {};
     return new AIMessageChunk({
       content,
       tool_call_chunks: toolCallChunks,
-      response_metadata: {
-        xHeaders: chunk.xHeaders,
-      },
+      response_metadata,
       additional_kwargs,
       id: chunk.xHeaders["xRequestID"] ?? uuidv4(),
     });


### PR DESCRIPTION
## Problem

When streaming responses from GigaChat, `xRequestID` and `xSessionID` in `response_metadata.xHeaders` grow with each chunk, producing corrupted values like:

```
xRequestID: "abc-123abc-123abc-123abc-123abc-123..." (1800+ characters)
xSessionID: "def-456def-456def-456def-456def-456..." (1800+ characters)
```

This happens because every `AIMessageChunk` created in `_convertDeltaToMessageChunk()` includes `response_metadata: { xHeaders: chunk.xHeaders }`. When `BaseMessageChunk.concat()` merges two chunks, LangChain's `merge_dicts` utility concatenates string values from `response_metadata`. After N streaming chunks, each header value is repeated N times.

## Root Cause

In `libs/langchain-gigachat/src/chat_models.ts`, the `_convertDeltaToMessageChunk` function (line 472-480):

```typescript
return new AIMessageChunk({
  content,
  tool_call_chunks: toolCallChunks,
  response_metadata: {
    xHeaders: chunk.xHeaders,  // ← Set on EVERY chunk
  },
  additional_kwargs,
  id: chunk.xHeaders["xRequestID"] ?? uuidv4(),
});
```

This is then concatenated in `_generate` (line 531):
```typescript
finalChunk = finalChunk.concat(chunk);  // merge_dicts concatenates strings
```

## Fix

Only include `xHeaders` in `response_metadata` on the **first** streaming chunk (`index === 0`). Subsequent chunks get empty `response_metadata`, so `concat()` has nothing to merge. The final concatenated message retains the correct, single header values from the first chunk.

## Impact

- Fixes corrupted `xRequestID` / `xSessionID` in streaming responses
- No behavior change for non-streaming calls
- The `id` field on each chunk (set from `xHeaders["xRequestID"]`) is unaffected — it was already correct since it's set per-chunk, not concatenated

🤖 Generated with [Claude Code](https://claude.com/claude-code)